### PR TITLE
Return promise arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const wrap = fn => new Promise(resolve => {
 });
 
 module.exports = (condition, action) => wrap(function loop() {
-	if (condition()) {
+	if (condition.apply(null, arguments)) {
 		return wrap(action).then(loop);
 	}
 });

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const wrap = fn => new Promise(resolve => {
 	resolve(fn());
 });
 
-module.exports = (condition, action) => wrap(function loop() {
-	if (condition.apply(null, arguments)) {
+module.exports = (condition, action) => wrap(function loop(actionResult) {
+	if (condition(actionResult)) {
 		return wrap(action).then(loop);
 	}
 });

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,8 @@ While `condition` returns `true`, executes `action` repeatedly, and then resolve
 
 Type: `Function`
 
+Arguments: whatever the `action` function returns
+
 Expected to return a boolean of whether to execute `action`.
 
 #### action

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,8 @@ While `condition` returns `true`, executes `action` repeatedly, and then resolve
 
 #### condition
 
-Type: `Function`
-
-Arguments: whatever the `action` function returns
+Type: `Function`<br>
+Arguments: Whatever the `action` function returns
 
 Expected to return a boolean of whether to execute `action`.
 

--- a/test.js
+++ b/test.js
@@ -16,6 +16,20 @@ test('main', async t => {
 	t.deepEqual(result, [0, 1, 2, 3, 4, 5, 6]);
 });
 
+test('condition receives action result', async t => {
+	const result = [];
+
+	await m(
+		r => r === undefined || r.length < 7,
+		() => {
+			result.push(result.length);
+			return result;
+		}
+	);
+
+	t.deepEqual(result, [0, 1, 2, 3, 4, 5, 6]);
+});
+
 test('works with action returning a promise', async t => {
 	const result = [];
 	let counter = 0;


### PR DESCRIPTION
- Fixes #2. `condition.apply(...)` was used instead of `condition(...)` in order not to enumerate the arguments to avoid limiting their number.
- Updated readme.
- Added test.